### PR TITLE
A few small fixes I found

### DIFF
--- a/Preemption_Notes.md
+++ b/Preemption_Notes.md
@@ -35,13 +35,10 @@ while the scheduler is running (after the SVC)! We did at least make sure that n
 will preempt the other when we set *both* their priorities to the lowest level.
 - If the timer gets in before the SVC instruction executes, then the task misses the boat and will skip
 a turn when it resumes and executes the SVC instruction. (So sad!)
-- If both the SVC and systick happen at the same time then SVC wins with a lower exception number and
-the systick interrupt will be pending. This is the same as systick expiring while the scheduler is running 
-because of an SVC, and will be discussed below.
-- I think it's unlikely but it may be possible for the processor to decide to take the exception for the
-systick interrupt in just such a way that the SVC still gets executed and the SVC interrupt ends up pending while
-the systick one is processed. The would cause two context switches in a row so that the task after the preempted 
-one would skip a turn. (So sorry!) I don't think it can happen, and it is ugly to fix, so I propose to ignore it.
+- If both the SVC and Systick happen at the same time then SVC wins with a lower exception number and
+the Systick interrupt will be pending. This is the same as Systick expiring while the scheduler is running 
+because of an SVC, and will be discussed below. (Note that *at the same time* here means that Systick fires
+during the execution of the SVC instruction.)
 - The systick timer can expire while the scheduler is running due to an SVC instruction. The scheduler is the
 exception handler and will not be preempted by the systick interrupt because they are at the same
 priority level. But the systick exception will be pending and will happen as soon as the scheduler switches to 

--- a/context_switch.s
+++ b/context_switch.s
@@ -13,11 +13,14 @@
 .thumb
 .syntax unified
 
+
 .type isr_svcall, %function
 .global isr_svcall
 .type isr_systick, %function
 .global isr_systick
+.thumb_func
 isr_svcall:
+.thumb_func
 isr_systick:
 	mrs r0, psp
 
@@ -70,6 +73,8 @@ isr_systick:
     pop {pc}
 
 .global __piccolo_pre_switch
+.type __piccolo_pre_switch,%function
+.thumb_func
 __piccolo_pre_switch:
 	/* save kernel state */
     /*
@@ -125,6 +130,8 @@ __piccolo_pre_switch:
 	bx lr
 
 .global __piccolo_task_init_stack
+.type __piccolo_task_init_stack,%function
+.thumb_func
 __piccolo_task_init_stack:
 	/* save kernel state */
     /*
@@ -160,8 +167,12 @@ __piccolo_task_init_stack:
 	/* same as bl piccolo_syscall, if the code wasn't below */
 
 .global piccolo_yield
+.type piccolo_yield,%function
 .global piccolo_syscall
+.type piccolo_syscall,%function
+.thumb_func
 piccolo_yield:
+.thumb_func
 piccolo_syscall:
     nop
 	svc 0

--- a/piccolo_os_demo.c
+++ b/piccolo_os_demo.c
@@ -6,9 +6,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include "pico/stdlib.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include "pico/stdlib.h"
 
 #include "piccolo_os.h"
 

--- a/piccolo_os_lock_core_v1.1.h
+++ b/piccolo_os_lock_core_v1.1.h
@@ -22,6 +22,8 @@
 
 /* force mutex for malloc even if multicore is not loaded */
 #define PICO_USE_MALLOC_MUTEX 1
+/* Protect divider from pre-emption */
+#define PICO_DIVIDER_DISABLE_INTERRUPTS true
 
 
 


### PR DESCRIPTION
There are 4 changes I propose
- Add the .thumb_func directives to context_switch.s. I haven't been able to make v1.1 do it, by in Plus I moved various things to RAM and got the loader to try to use a blx instruction in the veneer calls. (Instant hard fault!) Adding the .thumb_func directives fixes it.
- Context switching does not save the context of the hardware divider. (oops!) Preemption could cause multiple tasks doing divides or floating point operations to malfunction. There is a flag to fix this (curiously only documented in the SDK release notes...) which is now in the "lock_core.h" file.
- I learned that the third bullet in the "race conditions" in my preemption notes is absolute bollocks. The instruction stream gets synced with the "async" exemptions and the SVC gets executed or it does not. The SVC interrupt cannot occur when another exception handler is active unless someone foolish calls yield inside an ISR. You get a hard fault if you do, since the SVC ISR cannot preempt anybody so you get priority escalation . So I took the bullet out and clarified the second one just a bit.
- I moved the include for "pico/stdlib.h" so the pico defaults don't get overridden by the regular stdlib.h. In particular you get %lld support, but who knows what other side effects there might be. At least now you get the standard Pico behavior.

Who knew that "embedded" was so full of ankle breaking gopher holes...I guess I should have remembered.